### PR TITLE
Fixed the sign up text fields

### DIFF
--- a/src/pages/signUp/signup-landscape-mode.css
+++ b/src/pages/signUp/signup-landscape-mode.css
@@ -3,7 +3,7 @@
 }
 
 /****** Landscape View Mode ******/
-@media only screen and (min-width: 480px) and (max-width: 916px) and (max-height: 415px) and (orientation: landscape) {
+@media only screen and (min-width: 480px) and (max-width: 932px) and (max-height: 431px) and (orientation: landscape) {
     div#login {
         text-align: center;
     }
@@ -22,13 +22,13 @@
     .MuiFormControl-root.MuiFormControl-fullWidth.MuiTextField-root {
         width: 30rem;
     }
+    
     /* Affects iphone viewport*/
     .description div {
         width: 30.1rem;
     }
 
     .description {
-        /* margin-left: 3.8rem; */
         display: flex;
         justify-content: center;
     }
@@ -41,7 +41,7 @@
         margin-bottom: 10px;
         margin-left: 0rem;
     }
-    /**/
+
     .MuiGrid-root.MuiGrid-item.MuiGrid-grid-xs-12.MuiGrid-grid-sm-6 {
         padding-top: 8px;
         padding-bottom: 8px;
@@ -67,6 +67,7 @@
         display: flex;
         justify-content: center;
     }
+
     .buttonGrid .MuiButton-fullWidth {
         height: 14vh;
     }
@@ -99,11 +100,11 @@
 /* Targets iPhone 4 */
 @media only screen and (min-width: 480px) and (max-height: 320px) and (orientation: landscape) {
     /* Affects iphone viewport*/
-    .MuiFormControl-root.MuiFormControl-fullWidth.MuiTextField-root.css-wb57ya-MuiFormControl-root-MuiTextField-root {
+    .MuiFormControl-root.MuiFormControl-fullWidth.MuiTextField-root {
         width: 25rem;
     }
     /* Affects iphone viewport*/
-    .description div.css-md26zr-MuiInputBase-root-MuiOutlinedInput-root {
+    .description div {
         width: 25rem;
     }
 


### PR DESCRIPTION
## Describe the Changes
- A short, clear and concise description of what this pull request do.
Adjusted the css that targets the text fields because each text fields at the sign-up page for iphone 4 takes up the entire space of the page.
 
## Screenshots:
- Add screenshot where applicable.
## Before:
![image](https://github.com/ettienekorayyi/worklog/assets/19362078/8ae875f3-f8bc-469b-86b0-4d14b8b97954)

## After
![image](https://github.com/ettienekorayyi/worklog/assets/19362078/ea0d9400-2c54-4855-8cd4-ca46f5c10e3e)


## Related Ticket
- Add the link of the ticket this pull request is resolving.
  
## Unit Tests Cases / E2E Tests Cases
- Where applicable, indicate the test results recorded.
- If manual tests are only applicable, outline the steps needed to perform the tests.

## Advice for Reviewers & Testing Notes 
- Explain how your change should be reviewed, and where reviewers should direct their attention.
- Explain (where relevant) how your change can be tested.

## Did you test this ticket on all browsers?
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Internet Explorer
